### PR TITLE
map Azure `DiscriminatedObjectType` to Terraform's `DynamicPseudoType`

### DIFF
--- a/pkg/attribute.go
+++ b/pkg/attribute.go
@@ -47,7 +47,7 @@ func restoreToNestedBlockSchema(attr *tfjson.SchemaAttribute) *tfjson.SchemaBloc
 		fields = attributeType.ElementType().AttributeTypes()
 	}
 	for s, t := range fields {
-		if t.IsPrimitiveType() || (t.IsCollectionType() && t.ElementType().IsPrimitiveType()) {
+		if t.IsPrimitiveType() || t == cty.DynamicPseudoType || (t.IsCollectionType() && t.ElementType().IsPrimitiveType()) {
 
 			newAttr := &tfjson.SchemaAttribute{
 				AttributeType: t,

--- a/pkg/azapi/azapi_resource_type.go
+++ b/pkg/azapi/azapi_resource_type.go
@@ -138,6 +138,10 @@ func convertAzApiTypeToCtyType(azApiType types.TypeBase) *cty.Type {
 			}
 			return toObjectType(t)
 		}
+	case *types.DiscriminatedObjectType:
+		{
+			return toDiscriminatedObjectType(t)
+		}
 	case *types.UnionType:
 		{
 			if len(t.Elements) == 0 {
@@ -173,6 +177,10 @@ func toObjectType(t *types.ObjectType) *cty.Type {
 		ctyType = cty.ObjectWithOptionalAttrs(properties, optionalList)
 	}
 	return &ctyType
+}
+
+func toDiscriminatedObjectType(t *types.DiscriminatedObjectType) *cty.Type {
+	return &cty.DynamicPseudoType
 }
 
 func isRequired(p types.ObjectProperty) bool {

--- a/pkg/generate_command_azapi_resource_test.go
+++ b/pkg/generate_command_azapi_resource_test.go
@@ -1,0 +1,21 @@
+package pkg
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestAzApiResourceWithDiscriminatedObjectType(t *testing.T) {
+	sut := azApiResourceGenerateCommand{
+		resourceType: "Microsoft.RecoveryServices/vaults/backupPolicies",
+		apiVersion:   "2024-10-01",
+		cfg:          Config{},
+	}
+	schema, err := sut.Schema()
+	require.NoError(t, err)
+	assert.NotNil(t, schema)
+	cfg, err := GenerateResource(sut)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -44,6 +44,8 @@ func ctyTypeToVariableTypeString(t cty.Type) string {
 		return "number"
 	case cty.Bool:
 		return "bool"
+	case cty.DynamicPseudoType:
+		return "any"
 	}
 	if t.SetElementType() != nil {
 		return fmt.Sprintf("set(%s)", ctyTypeToVariableTypeString(t.ElementType()))

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	azurermschema "github.com/lonegunmanb/terraform-azurerm-schema/v3/generated"
 	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestGenerateVariableType_ObjectTypeInAttributes(t *testing.T) {
@@ -17,4 +18,9 @@ func TestGenerateVariableType_ObjectTypeInAttributes(t *testing.T) {
   protocol = string
 }))`, " ", "", -1)
 	assert.Equal(t, expected, actual)
+}
+
+func TestGenerateVariableType_DynamicTypeShouldBeGeneratedAsAny(t *testing.T) {
+	actual := ctyTypeToVariableTypeString(cty.DynamicPseudoType)
+	assert.Equal(t, "any", actual)
 }


### PR DESCRIPTION
This pr is just a temporary workaround for #320, need further patches.