### PR TITLE
bump helm to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/lonegunmanb/terraform-aws-schema/v3 v3.76.1
 	github.com/lonegunmanb/terraform-aws-schema/v4 v4.67.0
 	github.com/lonegunmanb/terraform-aws-schema/v5 v5.100.0
-	github.com/lonegunmanb/terraform-aws-schema/v6 v6.0.0
+	github.com/lonegunmanb/terraform-aws-schema/v6 v6.2.0
 	github.com/lonegunmanb/terraform-awscc-schema v1.48.0
 	github.com/lonegunmanb/terraform-azapi-schema v1.15.0
 	github.com/lonegunmanb/terraform-azapi-schema/v2 v2.5.0
@@ -31,11 +31,12 @@ require (
 	github.com/lonegunmanb/terraform-google-schema/v5 v5.45.0
 	github.com/lonegunmanb/terraform-google-schema/v6 v6.42.0
 	github.com/lonegunmanb/terraform-helm-schema/v2 v2.17.0
+	github.com/lonegunmanb/terraform-helm-schema/v3 v3.0.2
 	github.com/lonegunmanb/terraform-kubernetes-schema/v2 v2.37.0
 	github.com/lonegunmanb/terraform-local-schema/v2 v2.5.3
 	github.com/lonegunmanb/terraform-modtm-schema v0.3.5
 	github.com/lonegunmanb/terraform-null-schema/v3 v3.2.4
-	github.com/lonegunmanb/terraform-random-schema/v3 v3.7.1-ephemeral
+	github.com/lonegunmanb/terraform-random-schema/v3 v3.7.2
 	github.com/lonegunmanb/terraform-template-schema/v2 v2.2.0
 	github.com/lonegunmanb/terraform-time-schema v0.13.0
 	github.com/lonegunmanb/terraform-tls-schema/v4 v4.1.0-ephemeral

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/lonegunmanb/terraform-aws-schema/v4 v4.67.0 h1:ssy4uMEFjijkxORGG+SyU3
 github.com/lonegunmanb/terraform-aws-schema/v4 v4.67.0/go.mod h1:QXLvpWSz5rNGenKQtdHpOlOh7cAet2BOgBXMjqoGYy4=
 github.com/lonegunmanb/terraform-aws-schema/v5 v5.100.0 h1:DxImqFYejw6OTyX+8/7jPyYfFsATjKggYCffghI2vZw=
 github.com/lonegunmanb/terraform-aws-schema/v5 v5.100.0/go.mod h1:+1dnKYWZOsaHEuEcTnqhtSjqhjg/o+zq1I1GXLM4gdE=
-github.com/lonegunmanb/terraform-aws-schema/v6 v6.0.0 h1:yKaJHpOHkRyDtSRboLnC1gOGO7VRm7kyZ9CFUt9CeU4=
-github.com/lonegunmanb/terraform-aws-schema/v6 v6.0.0/go.mod h1:PzejNn3seOfagL7ltKESgqmBF7dry/OstCxxdxIHdEc=
+github.com/lonegunmanb/terraform-aws-schema/v6 v6.2.0 h1:aX9KJHl5o6Pkq2T0lfGzHKZ4lNenkLmiLnNLyXzWjtQ=
+github.com/lonegunmanb/terraform-aws-schema/v6 v6.2.0/go.mod h1:PzejNn3seOfagL7ltKESgqmBF7dry/OstCxxdxIHdEc=
 github.com/lonegunmanb/terraform-awscc-schema v1.48.0 h1:VfIT4w5xKVHAseAeF8foW7WfkQ0L2CIIqngTYX4GhlE=
 github.com/lonegunmanb/terraform-awscc-schema v1.48.0/go.mod h1:qtPFv1JcZ+QKFTqg0Gwtch3ifVnvvjgh10GkllmdxRs=
 github.com/lonegunmanb/terraform-azapi-schema v1.15.0 h1:n5oGrSU1NerlGH/3bVNHdNl24fNfV3N3JtK2QEhxpIE=
@@ -64,6 +64,8 @@ github.com/lonegunmanb/terraform-google-schema/v6 v6.42.0 h1:sNVEILMrIqE2UC2jwP7
 github.com/lonegunmanb/terraform-google-schema/v6 v6.42.0/go.mod h1:XbKxTdcxNp+tYBN6Pz8Dl2qpoVfvm2DV18YPuP6v1rc=
 github.com/lonegunmanb/terraform-helm-schema/v2 v2.17.0 h1:Jrlb7VrXH7y+6lZTtNx3e3KH5fDiC2wHfJsRAR7oR/c=
 github.com/lonegunmanb/terraform-helm-schema/v2 v2.17.0/go.mod h1:980t3S4UuBp9yrgpdA5/kMvniOjNgPvamPivaY1hPto=
+github.com/lonegunmanb/terraform-helm-schema/v3 v3.0.2 h1:W9F06IO/Xh6AF7JDMtbaWoq3cDxRZVmjgjqy+WUfJnE=
+github.com/lonegunmanb/terraform-helm-schema/v3 v3.0.2/go.mod h1:7GkpRpM6OIuNeBZtQz7Tm64gP/C8FdMiVeKOcUB5PeY=
 github.com/lonegunmanb/terraform-kubernetes-schema/v2 v2.37.0 h1:BX3hL3y97/Ckd+0ChzYbBUlQh36n/9mAmnXVFisIYQs=
 github.com/lonegunmanb/terraform-kubernetes-schema/v2 v2.37.0/go.mod h1:15XANwYuVpPa/1gFSLYKNkRZVIK0uZaqo8WGTLytIxA=
 github.com/lonegunmanb/terraform-local-schema/v2 v2.5.3 h1:FSSLkdzd04pSDqY7qeRkwfvM6vJbCZIn1IE/VCa3TjA=
@@ -72,8 +74,8 @@ github.com/lonegunmanb/terraform-modtm-schema v0.3.5 h1:2ZmlgjGxBmvyNLf8zalRwFUJ
 github.com/lonegunmanb/terraform-modtm-schema v0.3.5/go.mod h1:BRDXpwV91y7Ii51J8lpTEqy+dG6CkfxbEgGW11Ql4KE=
 github.com/lonegunmanb/terraform-null-schema/v3 v3.2.4 h1:nYl7xeQEa/Zt0shgQZGFUinBonZkDPrO8T815uMxodQ=
 github.com/lonegunmanb/terraform-null-schema/v3 v3.2.4/go.mod h1:u/uSM6+Djhqho/UFpqGKo2t3iQG+EREqZMGysJvzew4=
-github.com/lonegunmanb/terraform-random-schema/v3 v3.7.1-ephemeral h1:WRyuF/9tirZEaZrkEYTwdF7VaI80twBJ4TJkQc3LKyc=
-github.com/lonegunmanb/terraform-random-schema/v3 v3.7.1-ephemeral/go.mod h1:GiWQAfSUSBUAZYPMWByBhlT7olBay40aL9BhGmjMPtA=
+github.com/lonegunmanb/terraform-random-schema/v3 v3.7.2 h1:8vsRChXRYjqEvHjCOkLQTF71/s1r7INFh5Y40fUQQBU=
+github.com/lonegunmanb/terraform-random-schema/v3 v3.7.2/go.mod h1:fjxLtDhghd5kojh4HAUyQt6jO1yx1iVpr47e4e+pAjQ=
 github.com/lonegunmanb/terraform-template-schema/v2 v2.2.0 h1:dbD4+ResOG4234ysG9HHXyZaYGynHefPzO70Rk/ktcs=
 github.com/lonegunmanb/terraform-template-schema/v2 v2.2.0/go.mod h1:FXrD523CXVw67Yn5xmlppTub47/1/UI+/SZjKq8G6X4=
 github.com/lonegunmanb/terraform-time-schema v0.13.0 h1:V4eCkgekQdET1VK/eIbEUnT9s+bHjzyuOeei4KNbmeA=

--- a/pkg/resource_register.go
+++ b/pkg/resource_register.go
@@ -23,6 +23,7 @@ import (
 	google_v5 "github.com/lonegunmanb/terraform-google-schema/v5/generated"
 	google_v6 "github.com/lonegunmanb/terraform-google-schema/v6/generated"
 	helm_v2 "github.com/lonegunmanb/terraform-helm-schema/v2/generated"
+	helm_v3 "github.com/lonegunmanb/terraform-helm-schema/v3/generated"
 	kubernetes_v2 "github.com/lonegunmanb/terraform-kubernetes-schema/v2/generated"
 	local "github.com/lonegunmanb/terraform-local-schema/v2/generated"
 	modtm "github.com/lonegunmanb/terraform-modtm-schema/generated"
@@ -58,6 +59,7 @@ func init() {
 		google_v5.Resources,
 		google_v6.Resources,
 		helm_v2.Resources,
+		helm_v3.Resources,
 		kubernetes_v2.Resources,
 		local.Resources,
 		null.Resources,


### PR DESCRIPTION
This pull request updates dependencies in the `go.mod` file and integrates a new version of the Terraform Helm schema (`v3`) into the project. The most important changes include updating library versions and registering the new Helm schema version in the resource registry.

### Dependency Updates:
* Updated `terraform-aws-schema/v6` from `v6.0.0` to `v6.2.0` in `go.mod`.
* Added `terraform-helm-schema/v3` at version `v3.0.2` to `go.mod`.
* Updated `terraform-random-schema/v3` from `v3.7.1-ephemeral` to `v3.7.2` in `go.mod`.

### Integration of Terraform Helm Schema v3:
* Added import for `terraform-helm-schema/v3/generated` as `helm_v3` in `pkg/resource_register.go`.
* Registered `helm_v3.Resources` in the resource registry initialization function in `pkg/resource_register.go`.